### PR TITLE
patch: update dependencies

### DIFF
--- a/esync/srvsync/esync_server.go
+++ b/esync/srvsync/esync_server.go
@@ -4,15 +4,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"reflect"
+	"slices"
+	"sync"
+	"sync/atomic"
+
 	"github.com/leap-fish/necs/esync"
 	"github.com/leap-fish/necs/router"
 	"github.com/yohamta/donburi"
 	"github.com/yohamta/donburi/component"
 	"golang.org/x/sync/errgroup"
-	"reflect"
-	"slices"
-	"sync"
-	"sync/atomic"
 )
 
 var NetworkIdCounter = atomic.Uint64{}

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -3,10 +3,10 @@ package main
 import (
 	"log"
 
+	"github.com/coder/websocket"
 	"github.com/leap-fish/necs/examples/shared"
 	"github.com/leap-fish/necs/router"
 	"github.com/leap-fish/necs/transports"
-	"nhooyr.io/websocket"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,16 @@ module github.com/leap-fish/necs
 go 1.23.0
 
 require (
-	github.com/hashicorp/go-msgpack v1.1.6
+	github.com/coder/websocket v1.8.12
+	github.com/hashicorp/go-msgpack/v2 v2.1.2
 	github.com/stretchr/testify v1.9.0
 	github.com/yohamta/donburi v1.15.4
 	golang.org/x/sync v0.8.0
-	nhooyr.io/websocket v1.8.17
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,12 @@
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/hashicorp/go-msgpack v1.1.6 h1:ww1OX2NJCNixx9/GB+Kp5NrYVlB6cSxa06RGrvjOwbw=
-github.com/hashicorp/go-msgpack v1.1.6/go.mod h1:iZfHWkHZuSrKnYYeBmJCgA/NttRmHeuccTEPp3rDGhM=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/hashicorp/go-msgpack/v2 v2.1.2 h1:4Ee8FTp834e+ewB71RDrQ0VKpyFdrKOjvYtnQ/ltVj0=
+github.com/hashicorp/go-msgpack/v2 v2.1.2/go.mod h1:upybraOAblm4S7rx0+jeNy+CWWhzywQsSRV5033mMu4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -26,5 +25,3 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-nhooyr.io/websocket v1.8.17 h1:KEVeLJkUywCKVsnLIDlD/5gtayKp8VoCkksHCGGfT9Y=
-nhooyr.io/websocket v1.8.17/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/router/network_client.go
+++ b/router/network_client.go
@@ -3,7 +3,8 @@ package router
 import (
 	"context"
 	"fmt"
-	"nhooyr.io/websocket"
+
+	"github.com/coder/websocket"
 )
 
 type NetworkClient struct {

--- a/router/router.go
+++ b/router/router.go
@@ -5,11 +5,12 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/leap-fish/necs/typeid"
-	"github.com/leap-fish/necs/typemapper"
-	"nhooyr.io/websocket"
 	"reflect"
 	"sync"
+
+	"github.com/coder/websocket"
+	"github.com/leap-fish/necs/typeid"
+	"github.com/leap-fish/necs/typemapper"
 )
 
 var (

--- a/transports/ws_client_transport.go
+++ b/transports/ws_client_transport.go
@@ -2,11 +2,12 @@ package transports
 
 import (
 	"context"
+	"time"
+
+	"github.com/coder/websocket"
 	"github.com/leap-fish/necs/router"
 	"github.com/leap-fish/necs/wrapws"
 	"golang.org/x/sync/errgroup"
-	"nhooyr.io/websocket"
-	"time"
 )
 
 type WsClientTransport struct {

--- a/transports/ws_server_transport.go
+++ b/transports/ws_server_transport.go
@@ -3,10 +3,11 @@ package transports
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/coder/websocket"
 	"github.com/leap-fish/necs/router"
 	"github.com/leap-fish/necs/wrapws"
-	"nhooyr.io/websocket"
-	"time"
 )
 
 type WsServerTransport struct {

--- a/typemapper/typemapper.go
+++ b/typemapper/typemapper.go
@@ -3,9 +3,10 @@ package typemapper
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/go-msgpack/codec"
 	"reflect"
 	"sync"
+
+	"github.com/hashicorp/go-msgpack/v2/codec"
 )
 
 // TypeMapper is used to map between registered IDs and components and
@@ -108,6 +109,22 @@ func (db *TypeMapper) Serialize(component any) ([]byte, error) {
 		return nil, err
 	}
 
+	// if customEncoder, ok := component.(EncodeDecoder); ok {
+	// 	encoded, err := customEncoder.Encode()
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+
+	// 	// if _, err := encodeBuf.Write(encoded); err != nil {
+	// 	// 	return nil, err
+	// 	// }
+	// 	if err := encoder.Encode(encoded); err != nil {
+	// 		return nil, err
+	// 	}
+
+	// 	fmt.Printf("message: %#v\n", encodeBuf.Bytes())
+	// } else {
+	// }
 	if err := encoder.Encode(component); err != nil {
 		return nil, err
 	}
@@ -117,6 +134,8 @@ func (db *TypeMapper) Serialize(component any) ([]byte, error) {
 
 // Deserialize a component by decoding its ID, and then the actual struct.
 func (db *TypeMapper) Deserialize(data []byte) (any, error) {
+	// buf := bytes.NewBuffer(data)
+	// decoder := codec.NewDecoder(buf, db.handle)
 	decoder := codec.NewDecoderBytes(data, db.handle)
 
 	var id uint
@@ -130,6 +149,24 @@ func (db *TypeMapper) Deserialize(data []byte) (any, error) {
 	}
 
 	instanced := reflect.New(component).Interface()
+	// if customDecoder, ok := instanced.(EncodeDecoder); ok {
+	// 	var remaining []byte
+	// 	if err := decoder.Decode(remaining); err != nil {
+	// 		return nil, err
+	// 	}
+	// 	// remaining, err := io.ReadAll(buf)
+	// 	// if err != nil {
+	// 	// 	fmt.Printf("read all buf: %s\n", err)
+	// 	// 	return nil, err
+	// 	// }
+
+	// 	if err := customDecoder.Decode(remaining); err != nil {
+	// 		return nil, err
+	// 	}
+
+	// 	fmt.Printf("instance: %v\n", instanced)
+	// } else {
+	// }
 	if err := decoder.Decode(instanced); err != nil {
 		return nil, err
 	}

--- a/typemapper/typemapper.go
+++ b/typemapper/typemapper.go
@@ -109,22 +109,6 @@ func (db *TypeMapper) Serialize(component any) ([]byte, error) {
 		return nil, err
 	}
 
-	// if customEncoder, ok := component.(EncodeDecoder); ok {
-	// 	encoded, err := customEncoder.Encode()
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
-
-	// 	// if _, err := encodeBuf.Write(encoded); err != nil {
-	// 	// 	return nil, err
-	// 	// }
-	// 	if err := encoder.Encode(encoded); err != nil {
-	// 		return nil, err
-	// 	}
-
-	// 	fmt.Printf("message: %#v\n", encodeBuf.Bytes())
-	// } else {
-	// }
 	if err := encoder.Encode(component); err != nil {
 		return nil, err
 	}
@@ -149,24 +133,6 @@ func (db *TypeMapper) Deserialize(data []byte) (any, error) {
 	}
 
 	instanced := reflect.New(component).Interface()
-	// if customDecoder, ok := instanced.(EncodeDecoder); ok {
-	// 	var remaining []byte
-	// 	if err := decoder.Decode(remaining); err != nil {
-	// 		return nil, err
-	// 	}
-	// 	// remaining, err := io.ReadAll(buf)
-	// 	// if err != nil {
-	// 	// 	fmt.Printf("read all buf: %s\n", err)
-	// 	// 	return nil, err
-	// 	// }
-
-	// 	if err := customDecoder.Decode(remaining); err != nil {
-	// 		return nil, err
-	// 	}
-
-	// 	fmt.Printf("instance: %v\n", instanced)
-	// } else {
-	// }
 	if err := decoder.Decode(instanced); err != nil {
 		return nil, err
 	}

--- a/typemapper/typemapper.go
+++ b/typemapper/typemapper.go
@@ -118,8 +118,6 @@ func (db *TypeMapper) Serialize(component any) ([]byte, error) {
 
 // Deserialize a component by decoding its ID, and then the actual struct.
 func (db *TypeMapper) Deserialize(data []byte) (any, error) {
-	// buf := bytes.NewBuffer(data)
-	// decoder := codec.NewDecoder(buf, db.handle)
 	decoder := codec.NewDecoderBytes(data, db.handle)
 
 	var id uint

--- a/wrapws/client.go
+++ b/wrapws/client.go
@@ -3,8 +3,9 @@ package wrapws
 import (
 	"context"
 	"io"
-	"nhooyr.io/websocket"
 	"time"
+
+	"github.com/coder/websocket"
 )
 
 type WebSocketClient struct {

--- a/wrapws/event_handler.go
+++ b/wrapws/event_handler.go
@@ -2,7 +2,8 @@ package wrapws
 
 import (
 	"context"
-	"nhooyr.io/websocket"
+
+	"github.com/coder/websocket"
 )
 
 type EventHandler interface {

--- a/wrapws/server.go
+++ b/wrapws/server.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"nhooyr.io/websocket"
 	"time"
+
+	"github.com/coder/websocket"
 )
 
 const maxMessageReadTime = time.Second * 30


### PR DESCRIPTION
update dependencies so you can utilize custom object marshaling/unmarshalling as well as update the `websocket` package since it was deprecated